### PR TITLE
Remove now unneeded jquery @require from the Greasemonkey userscript

### DIFF
--- a/greasemonkey.user.js
+++ b/greasemonkey.user.js
@@ -3,7 +3,6 @@
 // @namespace   http://darcsys.com
 // @include     https://twitter.com/*
 // @include     https://tweetdeck.com/*
-// @require     http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js
 // @version     1
 // @grant       none
 // ==/UserScript==


### PR DESCRIPTION
f086870 removed the code calling to jquery, but not its @require tag, which is no longer needed.
